### PR TITLE
package.json: bump juttle versioin to latest commit on master

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "classnames": "^2.2.1",
     "dagre": "^0.7.4",
     "jquery": "^2.1.4",
-    "juttle": "^0.1.0",
+    "juttle": "juttle/juttle#1a67f61d5075967c27cf9fe436b91741e6defffb",
     "react": "^0.14.3",
     "react-dom": "^0.14.5",
     "react-redux": "^4.0.6",

--- a/src/app.js
+++ b/src/app.js
@@ -17,7 +17,7 @@ function patchNodeEmit(node) {
     var origEmit = node.emit;
     node.emit = function(points, output_name) {
         points.forEach((point) => {
-            store.dispatch(Actions.nodeEmitPoint(node.pname, point));
+            store.dispatch(Actions.nodeEmitPoint(node.params.pname, point));
         });
 
         origEmit.apply(node, arguments);
@@ -29,7 +29,7 @@ function patchNodeConsume(node) {
     var origConsume = node.consume;
     node.consume = function(points, from) {
         points.forEach((point) => {
-            store.dispatch(Actions.nodeConsumePoint(node.pname, point));
+            store.dispatch(Actions.nodeConsumePoint(node.params.pname, point));
         });
 
         origConsume.apply(node, arguments);


### PR DESCRIPTION
- The location of `pname` in a proc instance changed from `this.pname` to `this.params.pname`.
